### PR TITLE
Fix mutually exclusive Resolver type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,8 @@ declare namespace resolve {
   }
 
   export type Resolver = Generator<
-    { package: URL } | { resolution: URL },
+    | { package: URL; resolution: undefined }
+    | { package: undefined; resolution: URL },
     number,
     void | boolean | JSON | null
   >


### PR DESCRIPTION
TypeScript doesn't behave intuitively in this case.  The prior implementation triggers the error: `Property 'resolution' does not exist on type Resolver`. 

The PR solution was found here: https://github.com/microsoft/TypeScript/issues/14094#issuecomment-285783297.